### PR TITLE
feat: implement JWT and JWKS foundation with security configuration a…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 ext {
     set('testcontainersVersion', '1.21.3')
+    set('jjwtVersion', '0.12.6')
 }
 
 dependencyManagement {
@@ -36,9 +37,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
 
     implementation 'org.flywaydb:flyway-core'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/authlyn/shared/config/SecurityConfig.java
+++ b/src/main/java/com/authlyn/shared/config/SecurityConfig.java
@@ -10,26 +10,46 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.authlyn.shared.security.jwt.AuthlynJwtProperties;
+import com.authlyn.shared.security.jwt.RsaKeyService;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http, AuthlynJwtProperties properties) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/public/**").permitAll()
-                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
-                        .anyRequest().permitAll());
+                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus", properties.getJwksPath()).permitAll()
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
 
         return http.build();
+    }
+
+    @Bean
+    JwtEncoder jwtEncoder(RsaKeyService rsaKeyService) {
+        return new NimbusJwtEncoder(new ImmutableJWKSet<>(new JWKSet(rsaKeyService.getSigningKey())));
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(RsaKeyService rsaKeyService) {
+        return NimbusJwtDecoder.withPublicKey(rsaKeyService.getPublicKey()).build();
     }
 
     @Bean

--- a/src/main/java/com/authlyn/shared/security/jwt/AuthlynJwtProperties.java
+++ b/src/main/java/com/authlyn/shared/security/jwt/AuthlynJwtProperties.java
@@ -1,0 +1,106 @@
+package com.authlyn.shared.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+@Component
+@Validated
+@ConfigurationProperties(prefix = "authlyn.jwt")
+public class AuthlynJwtProperties {
+
+    @NotBlank
+    private String issuer = "http://localhost:8080";
+
+    @NotBlank
+    private String kid = "authlyn-rsa-1";
+
+    @NotBlank
+    private String jwksPath = "/.well-known/jwks.json";
+
+    @Min(1)
+    private long accessTokenMinutes = 15;
+
+    @Min(1)
+    private long refreshTokenDays = 30;
+
+    private String privateKey;
+    private String privateKeyPath;
+    private String publicKey;
+    private String publicKeyPath;
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public String getKid() {
+        return kid;
+    }
+
+    public void setKid(String kid) {
+        this.kid = kid;
+    }
+
+    public String getJwksPath() {
+        return jwksPath;
+    }
+
+    public void setJwksPath(String jwksPath) {
+        this.jwksPath = jwksPath;
+    }
+
+    public long getAccessTokenMinutes() {
+        return accessTokenMinutes;
+    }
+
+    public void setAccessTokenMinutes(long accessTokenMinutes) {
+        this.accessTokenMinutes = accessTokenMinutes;
+    }
+
+    public long getRefreshTokenDays() {
+        return refreshTokenDays;
+    }
+
+    public void setRefreshTokenDays(long refreshTokenDays) {
+        this.refreshTokenDays = refreshTokenDays;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public String getPrivateKeyPath() {
+        return privateKeyPath;
+    }
+
+    public void setPrivateKeyPath(String privateKeyPath) {
+        this.privateKeyPath = privateKeyPath;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public String getPublicKeyPath() {
+        return publicKeyPath;
+    }
+
+    public void setPublicKeyPath(String publicKeyPath) {
+        this.publicKeyPath = publicKeyPath;
+    }
+}

--- a/src/main/java/com/authlyn/shared/security/jwt/JwksController.java
+++ b/src/main/java/com/authlyn/shared/security/jwt/JwksController.java
@@ -1,0 +1,24 @@
+package com.authlyn.shared.security.jwt;
+
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nimbusds.jose.jwk.JWKSet;
+
+@RestController
+public class JwksController {
+
+    private final RsaKeyService rsaKeyService;
+
+    public JwksController(RsaKeyService rsaKeyService) {
+        this.rsaKeyService = rsaKeyService;
+    }
+
+    @GetMapping(value = "${authlyn.jwt.jwks-path:/.well-known/jwks.json}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, Object> jwks() {
+        return new JWKSet(rsaKeyService.getPublicJwk()).toJSONObject();
+    }
+}

--- a/src/main/java/com/authlyn/shared/security/jwt/RsaKeyService.java
+++ b/src/main/java/com/authlyn/shared/security/jwt/RsaKeyService.java
@@ -1,0 +1,219 @@
+package com.authlyn.shared.security.jwt;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+
+@Service
+public class RsaKeyService {
+
+    private final AuthlynJwtProperties properties;
+    private final RSAKey signingKey;
+    private final RSAKey publicJwk;
+    private final RSAPublicKey publicKey;
+    private final RSAPrivateKey privateKey;
+
+    public RsaKeyService(AuthlynJwtProperties properties) {
+        this.properties = properties;
+        LoadedKeyPair keyPair = loadSigningKey();
+        this.signingKey = keyPair.signingKey();
+        this.publicJwk = keyPair.publicJwk();
+        this.publicKey = keyPair.publicKey();
+        this.privateKey = keyPair.privateKey();
+    }
+
+    public RSAKey getSigningKey() {
+        return signingKey;
+    }
+
+    public RSAKey getPublicJwk() {
+        return publicJwk;
+    }
+
+    public RSAPublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    public RSAPrivateKey getPrivateKey() {
+        return privateKey;
+    }
+
+    private LoadedKeyPair loadSigningKey() {
+        String privateKeySource = firstNonBlank(properties.getPrivateKeyPath(), properties.getPrivateKey());
+        String publicKeySource = firstNonBlank(properties.getPublicKeyPath(), properties.getPublicKey());
+
+        if (privateKeySource == null) {
+            if (publicKeySource != null) {
+                throw new IllegalStateException("AUTHLYN_JWT_PUBLIC_KEY(_PATH) was provided without a private key; set AUTHLYN_JWT_PRIVATE_KEY(_PATH) too.");
+            }
+            return generateEphemeralKey();
+        }
+
+        RSAPrivateKey loadedPrivateKey = parsePrivateKey(readKeyMaterial(privateKeySource));
+        RSAPublicKey loadedPublicKey = publicKeySource == null
+                ? derivePublicKey(loadedPrivateKey)
+                : parsePublicKey(readKeyMaterial(publicKeySource));
+
+        RSAPublicKey derivedPublicKey = derivePublicKey(loadedPrivateKey);
+        if (!publicKeysMatch(loadedPublicKey, derivedPublicKey)) {
+            throw new IllegalStateException("Configured public key does not match the configured private key.");
+        }
+
+        return buildKeyPair(loadedPrivateKey, loadedPublicKey);
+    }
+
+    private LoadedKeyPair generateEphemeralKey() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            KeyPair pair = generator.generateKeyPair();
+            return buildKeyPair((RSAPrivateKey) pair.getPrivate(), (RSAPublicKey) pair.getPublic());
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("RSA algorithm is not available on this JVM.", ex);
+        }
+    }
+
+    private LoadedKeyPair buildKeyPair(RSAPrivateKey privateKey, RSAPublicKey publicKey) {
+        String kid = hasText(properties.getKid()) ? properties.getKid() : defaultKid(publicKey);
+        RSAKey signingRsaKey = new RSAKey.Builder(publicKey)
+                .privateKey(privateKey)
+                .keyUse(KeyUse.SIGNATURE)
+                .algorithm(JWSAlgorithm.RS256)
+                .keyID(kid)
+                .build();
+
+        RSAKey publicRsaJwk = new RSAKey.Builder(publicKey)
+                .keyUse(KeyUse.SIGNATURE)
+                .algorithm(JWSAlgorithm.RS256)
+                .keyID(kid)
+                .build();
+
+        return new LoadedKeyPair(signingRsaKey, publicRsaJwk, publicKey, privateKey);
+    }
+
+    private String defaultKid(RSAPublicKey publicKey) {
+        return "authlyn-" + publicKey.getModulus().abs().toString(16).substring(0, 12);
+    }
+
+    private RSAPrivateKey parsePrivateKey(String pem) {
+        try {
+            byte[] decoded = decodePem(pem, "PRIVATE KEY");
+            return (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(decoded));
+        } catch (GeneralSecurityException | IllegalArgumentException ex) {
+            throw new IllegalStateException("Unable to load the configured RSA private key.", ex);
+        }
+    }
+
+    private RSAPublicKey parsePublicKey(String pem) {
+        try {
+            byte[] decoded = decodePem(pem, "PUBLIC KEY");
+            return (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(decoded));
+        } catch (GeneralSecurityException | IllegalArgumentException ex) {
+            throw new IllegalStateException("Unable to load the configured RSA public key.", ex);
+        }
+    }
+
+    private byte[] decodePem(String value, String type) {
+        String normalized = value
+                .replace("-----BEGIN " + type + "-----", "")
+                .replace("-----END " + type + "-----", "")
+                .replaceAll("\\s", "")
+                .trim();
+        return Base64.getDecoder().decode(normalized.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    private String readKeyMaterial(String value) {
+        if (!hasText(value)) {
+            throw new IllegalStateException("Key material cannot be blank.");
+        }
+
+        if (value.contains("-----BEGIN ")) {
+            return value;
+        }
+
+        if (value.startsWith("classpath:") || value.startsWith("file:")) {
+            Resource resource = new DefaultResourceLoader().getResource(value);
+            if (resource.exists()) {
+                try {
+                    return new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException ex) {
+                    throw new IllegalStateException("Unable to read RSA key resource: " + value, ex);
+                }
+            }
+        }
+
+        try {
+            Path path = Path.of(value);
+            if (Files.exists(path)) {
+                return Files.readString(path, StandardCharsets.UTF_8);
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to read RSA key file: " + value, ex);
+        } catch (RuntimeException ignored) {
+            // treat as inline key material
+        }
+
+        Resource resource = new DefaultResourceLoader().getResource(value);
+        if (resource.exists()) {
+            try {
+                return new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException ex) {
+                throw new IllegalStateException("Unable to read RSA key resource: " + value, ex);
+            }
+        }
+
+        return value;
+    }
+
+    private RSAPublicKey derivePublicKey(RSAPrivateKey privateKey) {
+        if (!(privateKey instanceof RSAPrivateCrtKey crtKey)) {
+            throw new IllegalStateException("Configured RSA private key does not expose CRT parameters required to derive the public key.");
+        }
+
+        try {
+            KeyFactory factory = KeyFactory.getInstance("RSA");
+            return (RSAPublicKey) factory.generatePublic(new RSAPublicKeySpec(crtKey.getModulus(), crtKey.getPublicExponent()));
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+            throw new IllegalStateException("Unable to derive the public key from the configured private key.", ex);
+        }
+    }
+
+    private boolean publicKeysMatch(RSAPublicKey configured, RSAPublicKey derived) {
+        return configured.getModulus().equals(derived.getModulus())
+                && configured.getPublicExponent().equals(derived.getPublicExponent());
+    }
+
+    private String firstNonBlank(String first, String second) {
+        if (hasText(first)) return first.trim();
+        if (hasText(second)) return second.trim();
+        return null;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private record LoadedKeyPair(RSAKey signingKey, RSAKey publicJwk, RSAPublicKey publicKey, RSAPrivateKey privateKey) {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,12 @@ spring:
           starttls:
             enable: ${AUTHLYN_MAIL_STARTTLS:false}
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${AUTHLYN_JWK_SET_URI:http://localhost:8080/.well-known/jwks.json}
+
 management:
   endpoints:
     web:
@@ -53,6 +59,10 @@ management:
         enabled: true
 
 authlyn:
+  jwt:
+    issuer: ${AUTHLYN_JWT_ISSUER:http://localhost:8080}
+    access-token-minutes: ${AUTHLYN_ACCESS_TOKEN_MINUTES:15}
+    refresh-token-days: ${AUTHLYN_REFRESH_TOKEN_DAYS:30}
   security:
     bcrypt-strength: ${AUTHLYN_BCRYPT_STRENGTH:12}
     trusted-proxy-cidrs: ${AUTHLYN_TRUSTED_PROXY_CIDRS:}

--- a/src/test/java/com/authlyn/shared/security/jwt/JwksControllerTest.java
+++ b/src/test/java/com/authlyn/shared/security/jwt/JwksControllerTest.java
@@ -1,0 +1,51 @@
+package com.authlyn.shared.security.jwt;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JwksControllerTest {
+
+    @Test
+    void exposesPublicJwks() throws Exception {
+        RSAKey jwk = createKey();
+        RsaKeyService rsaKeyService = new RsaKeyService(new AuthlynJwtProperties()) {
+            @Override
+            public RSAKey getPublicJwk() {
+                return jwk.toPublicJWK();
+            }
+        };
+
+        JwksController controller = new JwksController(rsaKeyService);
+        Map<String, Object> response = controller.jwks();
+
+        Map<?, ?> key = (Map<?, ?>) ((List<?>) response.get("keys")).get(0);
+        assertEquals("RSA", key.get("kty"));
+        assertEquals("test-kid", key.get("kid"));
+        assertEquals("sig", key.get("use"));
+        assertEquals("RS256", key.get("alg"));
+    }
+
+    private RSAKey createKey() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair pair = generator.generateKeyPair();
+        return new RSAKey.Builder((RSAPublicKey) pair.getPublic())
+                .privateKey((RSAPrivateKey) pair.getPrivate())
+                .keyID("test-kid")
+                .keyUse(KeyUse.SIGNATURE)
+                .algorithm(JWSAlgorithm.RS256)
+                .build();
+    }
+}

--- a/src/test/java/com/authlyn/shared/security/jwt/RsaKeyServiceTest.java
+++ b/src/test/java/com/authlyn/shared/security/jwt/RsaKeyServiceTest.java
@@ -1,0 +1,63 @@
+package com.authlyn.shared.security.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jose.jwk.RSAKey;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RsaKeyServiceTest {
+
+    @Test
+    void generatesAnEphemeralKeyWhenNothingIsConfigured() {
+        AuthlynJwtProperties properties = new AuthlynJwtProperties();
+        RsaKeyService service = new RsaKeyService(properties);
+
+        RSAKey signingKey = service.getSigningKey();
+
+        assertNotNull(signingKey);
+        assertTrue(signingKey.getKeyID().startsWith("authlyn-"));
+        assertNotNull(service.getPublicKey());
+        assertNotNull(service.getPrivateKey());
+    }
+
+    @Test
+    void loadsInlinePemKeys() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+
+        AuthlynJwtProperties properties = new AuthlynJwtProperties();
+        properties.setKid("test-kid");
+        properties.setPrivateKey(toPem("PRIVATE KEY", keyPair.getPrivate().getEncoded()));
+        properties.setPublicKey(toPem("PUBLIC KEY", keyPair.getPublic().getEncoded()));
+
+        RsaKeyService service = new RsaKeyService(properties);
+
+        RSAPublicKey publicKey = service.getPublicKey();
+        RSAPrivateKey privateKey = service.getPrivateKey();
+
+        assertEquals(((RSAPublicKey) keyPair.getPublic()).getModulus(), publicKey.getModulus());
+        assertEquals(((RSAPublicKey) keyPair.getPublic()).getPublicExponent(), publicKey.getPublicExponent());
+        assertEquals(((RSAPrivateKey) keyPair.getPrivate()).getModulus(), privateKey.getModulus());
+        assertEquals("test-kid", service.getSigningKey().getKeyID());
+    }
+
+    private KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    private String toPem(String type, byte[] encoded) {
+        String base64 = Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(encoded);
+        return "-----BEGIN " + type + "-----\n" + base64 + "\n-----END " + type + "-----";
+    }
+}


### PR DESCRIPTION


### Summary
Restores the JWT and JWKS foundation that was removed during the scaffold reset (task 00-03). This is the first identity-layer slice — it wires RSA key management, JWT signing/verification, and the public JWKS endpoint back into the backend without touching any user or session logic.

### What changed
* **`build.gradle`** — added `spring-boot-starter-oauth2-resource-server`, `spring-boot-starter-oauth2-client`, and the JJWT 0.12.6 dependency group.
* **`application.yml`** — added `authlyn.jwt.*` properties (issuer, token expiry) and `spring.security.oauth2.resourceserver.jwt.jwk-set-uri`.
* **`AuthlynJwtProperties`** — `@ConfigurationProperties` binding for the `authlyn.jwt` namespace, including optional key path/inline fields for production key injection.
* **`RsaKeyService`** — loads RSA keys from a configured path or inline PEM; falls back to a generated ephemeral 2048-bit key pair when nothing is configured (safe for local dev).
* **`JwksController`** — serves the public key set at `/.well-known/jwks.json`; exposes only the public JWK, never the private key.
* **`SecurityConfig`** — adds `JwtEncoder` and `JwtDecoder` beans backed by `RsaKeyService`; switches `anyRequest()` from `permitAll` to `authenticated`; permits the JWKS path publicly so clients can bootstrap.

### Checklist
- [x] I ran the Gradle test suite locally
- [x] I updated documentation if needed
- [x] I considered configuration or security impact
- [x] I kept the change focused and easy to review

### Notes
No key files are committed. In production, inject `AUTHLYN_JWT_PRIVATE_KEY_PATH` (or the inline `AUTHLYN_JWT_PRIVATE_KEY` env var). Without either, the service generates an ephemeral key on startup — tokens are invalidated on every restart.

The `JwtDecoder` bean overrides the auto-configured one that would otherwise try to fetch the JWKS over HTTP on startup, breaking the boot cycle when the server itself hasn't finished starting.

**Follow-up:** [[01-02 - user persistence and password hashing](https://www.google.com/search?q=vscode-webview://1t3658ldl8g82nbr37io97618v2s0urf0ffsm4b232lg0nf1sm6q/docs/tasks/01-02-user-persistence-and-password-hashing.md)](vscode-webview://1t3658ldl8g82nbr37io97618v2s0urf0ffsm4b232lg0nf1sm6q/docs/tasks/01-02-user-persistence-and-password-hashing.md).